### PR TITLE
Add coloring for encapsulation types

### DIFF
--- a/SharpLizer/Classification/ClassificationTypes.cs
+++ b/SharpLizer/Classification/ClassificationTypes.cs
@@ -30,9 +30,12 @@ namespace SharpLizer.Classification
             public const string StructKeyword = "SharpLizer.StructKeyword";
         }
 
+        public const string EncapsulationKeywords = "SharpLizer.EncapsulationKeywords";
+
         public const string FieldType = "SharpLizer.FieldType";
         public const string MethodType = "SharpLizer.MethodType";
         public const string ConstantFieldType = "SharpLizer.ConstantFieldType";
+        
 
     }
 }

--- a/SharpLizer/Classification/ClassifierProvider.cs
+++ b/SharpLizer/Classification/ClassifierProvider.cs
@@ -59,6 +59,7 @@ namespace SharpLizer.Classification
             classificationTypes.Add(ClassificationTypes.DeclarationTypes.InterfaceKeyword, classificationRegistry.GetClassificationType(ClassificationTypes.DeclarationTypes.InterfaceKeyword));
             classificationTypes.Add(ClassificationTypes.DeclarationTypes.NamespaceKeyword, classificationRegistry.GetClassificationType(ClassificationTypes.DeclarationTypes.NamespaceKeyword));
             classificationTypes.Add(ClassificationTypes.DeclarationTypes.StructKeyword, classificationRegistry.GetClassificationType(ClassificationTypes.DeclarationTypes.StructKeyword));
+            classificationTypes.Add(ClassificationTypes.EncapsulationKeywords, classificationRegistry.GetClassificationType(ClassificationTypes.EncapsulationKeywords));
 
             return classificationTypes;
         }

--- a/SharpLizer/Classification/ClassifierTypeDefinitions.cs
+++ b/SharpLizer/Classification/ClassifierTypeDefinitions.cs
@@ -103,6 +103,11 @@ namespace SharpLizer.Classification
 
         #endregion
 
+        [Export(typeof(ClassificationTypeDefinition))]
+        [ClassificationType(ClassificationTypeNames = ClassificationTypes.EncapsulationKeywords)]
+        [Name(ClassificationTypes.EncapsulationKeywords)]
+        private static ClassificationTypeDefinition encapsulationKeywordsDefinition;
+
 #pragma warning restore 169
     }
 }

--- a/SharpLizer/Classification/ColorFormats.cs
+++ b/SharpLizer/Classification/ColorFormats.cs
@@ -52,7 +52,7 @@ namespace SharpLizer.Classification
     [Export(typeof(EditorFormatDefinition))]
     [ClassificationType(ClassificationTypeNames = ClassificationTypes.AbstractionTypes.AbstractionKeywords)]
     [Name(ClassificationTypes.AbstractionTypes.AbstractionKeywords)]
-    [UserVisible(true)] // This should be visible to the end user
+    [UserVisible(false)] // This should be visible to the end user
     [Order(After = Priority.High)] // Set the priority to be after the default classifiers
     internal sealed class AbstractionKeywordsClassification : ClassificationFormatDefinition
     {
@@ -189,7 +189,7 @@ namespace SharpLizer.Classification
     [Export(typeof(EditorFormatDefinition))]
     [ClassificationType(ClassificationTypeNames = ClassificationTypes.DeclarationTypes.DeclarationKeywords)]
     [Name(ClassificationTypes.DeclarationTypes.DeclarationKeywords)]
-    [UserVisible(true)] // This should be visible to the end user
+    [UserVisible(false)] // This should be visible to the end user
     [Order(After = Priority.High)] // Set the priority to be after the default classifiers
     internal sealed class DeclarationKeywordsClassification : ClassificationFormatDefinition
     {
@@ -198,7 +198,7 @@ namespace SharpLizer.Classification
         /// </summary>
         public DeclarationKeywordsClassification()
         {
-            this.DisplayName = "SharpLizer: Class Keyword"; // Human readable version of the name
+            this.DisplayName = "SharpLizer: Declaration Keywords"; // Human readable version of the name
             this.ForegroundColor = Colors.Yellow;
             this.TextDecorations = System.Windows.TextDecorations.Underline;
         }
@@ -314,4 +314,22 @@ namespace SharpLizer.Classification
     }
 
     #endregion
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.EncapsulationKeywords)]
+    [Name(ClassificationTypes.EncapsulationKeywords)]
+    [UserVisible(true)] // This should be visible to the end user
+    [Order(After = Priority.High)] // Set the priority to be after the default classifiers
+    internal sealed class EncapsulationKeywordsClassification : ClassificationFormatDefinition
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EncapsulationKeywordsClassification"/> class.
+        /// </summary>
+        public EncapsulationKeywordsClassification()
+        {
+            this.DisplayName = "SharpLizer: Encapsulation Keywords"; // Human readable version of the name
+            this.ForegroundColor = Colors.Aqua;
+            this.TextDecorations = System.Windows.TextDecorations.Underline;
+        }
+    }
 }

--- a/SharpLizer/Classification/EditorClassifier.cs
+++ b/SharpLizer/Classification/EditorClassifier.cs
@@ -160,6 +160,13 @@ namespace SharpLizer.Classification
                         return _classifications[ClassificationTypes.DeclarationTypes.StructKeyword];
                     #endregion
 
+                    #region Encapsulation Keywords
+                    case SyntaxKind.PublicKeyword:
+                    case SyntaxKind.PrivateKeyword:
+                    case SyntaxKind.InternalKeyword:
+                    case SyntaxKind.ProtectedKeyword:
+                        return _classifications[ClassificationTypes.EncapsulationKeywords];
+                    #endregion
 
                     default:
                         return null;

--- a/SharpLizer/SharpLizer.csproj
+++ b/SharpLizer/SharpLizer.csproj
@@ -56,7 +56,6 @@
     <Compile Include="Configuration\CategorySettings.cs" />
     <Compile Include="Configuration\ColorSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestClass.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
-Add coloring for keywords like public, private, etc
-Hide Abtrastaction and Declaration Keywords coloring from the menu. These will be used later when implementing the custom options page.